### PR TITLE
Expanded datagram buffer length

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <groupId>org.jinglenodes</groupId>
     <artifactId>sjbundle</artifactId>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>1.0.9</version>
 
     <build>
         <plugins>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>lighter</groupId>
             <artifactId>lighter</artifactId>
-            <version>1.3.1-SNAPSHOT</version>
+            <version>1.3.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/xmpp/jnodes/nio/SelDatagramChannel.java
+++ b/src/main/java/org/xmpp/jnodes/nio/SelDatagramChannel.java
@@ -20,6 +20,8 @@ public class SelDatagramChannel implements ListenerDatagramChannel {
     protected final DatagramChannel channel;
     private DatagramListener datagramListener;
     private final static Object obj = new Object();
+    
+    private static final int MAX_DATAGRAM_LENGTH = 2048;
 
     private static void init() {
         try {
@@ -63,7 +65,7 @@ public class SelDatagramChannel implements ListenerDatagramChannel {
                                         continue;
                                     }
 
-                                    final ByteBuffer b = ByteBuffer.allocateDirect(1450);
+                                    final ByteBuffer b = ByteBuffer.allocateDirect(MAX_DATAGRAM_LENGTH);
                                     final SocketAddress clientAddress;
                                     synchronized (sdc) {
                                         clientAddress = sdc.channel.receive(b);


### PR DESCRIPTION
We started getting SIP requests which go over the 1450 byte limit. Expanded this and made it easier to understand.
